### PR TITLE
Add clear map button and add visual preview for flag/HQ territory

### DIFF
--- a/layout-planner/index.html
+++ b/layout-planner/index.html
@@ -17,17 +17,18 @@
     
     <!-- Top Controls -->
     <div id="topControls"
-        class="fixed top-4 left-0 right-0 z-40 pointer-events-none">
+        class="fixed top-4 left-0 right-0 z-40 pointer-events-none flex justify-center">
         <!-- Wrapper-->
-        <div class="mx-auto w-full max-w-xl px-4">
+        <div class="px-4">
             <!-- White Card -->
             <div class="bg-white shadow-lg rounded-lg pointer-events-auto">
-                <div class="w-full flex items-center px-4 py-3 gap-4">
+                <div class="flex items-center px-4 py-3 gap-4">
                     <!-- Controls Group -->
                     <div id="toolbar-controls" class="flex items-center gap-2 flex-nowrap">
                         <button data-type="select" class="bg-gray-500 hover:bg-gray-600 text-white px-4 py-2 rounded-lg text-sm font-medium">Select</button>
                         <button data-type="move"   class="bg-purple-500 hover:bg-purple-600 text-white px-4 py-2 rounded-lg text-sm font-medium">Pan</button>
                         <button id="deleteButton"  class="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-lg text-sm font-medium">Delete</button>
+                        <button id="clearButton"   class="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-lg text-sm font-medium">Clear</button>
                     </div>
 
                     <div class="h-8 w-px bg-gray-300 hidden md:block"></div>


### PR DESCRIPTION
This pull request makes a small UI improvement to the top controls in the `layout-planner` interface. The main change is the addition of a new "Clear" button to the toolbar, alongside a minor adjustment to the layout for better centering.

- **UI Enhancements:**
  * Added a "Clear" button (`clearButton`) to the toolbar controls for improved user functionality.
  * Updated the layout to use `flex justify-center` on the top controls, improving horizontal centering of the toolbar.
  * Added visual preview of flag/HQ territory during placement.
  * Increased grid size.

- **Export Enhancements:**
  * PNG and CSV exports now use the map name for filenames and prevent exporting empty maps.