### PR TITLE
65 layout planner controls

### DIFF
--- a/layout-planner/css/style.css
+++ b/layout-planner/css/style.css
@@ -1,4 +1,9 @@
 /* Essential canvas and positioning that can't be replaced with Tailwind */
+html,
+body {
+    touch-action: manipulation;
+}
+
 body {
     margin: 0;
     padding: 0;

--- a/layout-planner/css/style.css
+++ b/layout-planner/css/style.css
@@ -20,6 +20,75 @@ body {
     display: block;
 }
 
+#layoutCanvas.eraser-cursor-active {
+    cursor: none !important;
+}
+
+.eraser-cursor {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 80;
+    pointer-events: none;
+    color: rgba(255, 255, 255, 0.95);
+    text-shadow: 0 1px 2px rgba(15, 23, 42, 0.45);
+    transform: translate(-3px, -5px) rotate(-12deg);
+    opacity: 0;
+    transition: opacity 0.08s linear;
+}
+
+.eraser-cursor.visible {
+    opacity: 1;
+}
+
+.eraser-cursor .material-symbols-outlined {
+    font-size: 26px;
+    line-height: 1;
+    font-variation-settings:
+        'FILL' 1,
+        'wght' 500,
+        'GRAD' 0,
+        'opsz' 24;
+}
+
+.shortcut-toast {
+    position: fixed;
+    top: 80px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 70;
+    pointer-events: none;
+    background: rgba(17, 24, 39, 0.92);
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.45rem 0.65rem;
+    border-radius: 0.375rem;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+}
+
+.shortcut-toast.visible {
+    opacity: 1;
+}
+
+.shortcut-button {
+    position: relative;
+    padding-right: 1.45rem;
+}
+
+.shortcut-hint {
+    position: absolute;
+    right: 0.35rem;
+    bottom: 0.2rem;
+    font-size: 0.6rem;
+    line-height: 1;
+    font-weight: 700;
+    opacity: 0.8;
+    color: rgba(255, 255, 255, 0.9);
+    pointer-events: none;
+}
+
 .bt-bubble.selected {
     background-color: #a3e635;
 }

--- a/layout-planner/index.html
+++ b/layout-planner/index.html
@@ -8,12 +8,16 @@
     <meta property="og:url" content="https://wosnerds.com/layout-planner/index.html">
     <link rel="stylesheet" href="/dist/css/tailwind.css?v=2">
     <link rel="stylesheet" href="/layout-planner/css/style.css">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=airwave,grid_on,group,import_contacts,ink_eraser,schedule&display=swap" />
     <title>Alliance Layout Planner</title>
 </head>
 <body class="overflow-hidden">
     <!-- Fullscreen Canvas -->
     <canvas id="layoutCanvas"></canvas>
+    <div id="shortcutToast" class="shortcut-toast"></div>
+    <div id="eraserCursor" class="eraser-cursor" aria-hidden="true">
+        <span class="material-symbols-outlined">ink_eraser</span>
+    </div>
     
     <!-- Top Controls -->
     <div id="topControls"
@@ -25,12 +29,12 @@
                 <div class="flex items-center px-4 py-3 gap-4">
                     <!-- Controls Group -->
                     <div id="toolbar-controls" class="flex items-center gap-2 flex-wrap md:flex-nowrap">
-                        <button data-type="select" class="bg-gray-500 hover:bg-gray-600 text-white px-3 py-2 rounded-lg text-sm font-medium flex-none min-w-max md:min-w-0 leading-5">Select</button>
-                        <button data-type="move"   class="bg-purple-500 hover:bg-purple-600 text-white px-3 py-2 rounded-lg text-sm font-medium flex-none min-w-max md:min-w-0 leading-5">Pan</button>
-                        <button id="deleteButton"  class="bg-red-500 hover:bg-red-600 text-white px-3 py-2 rounded-lg text-sm font-medium flex-none min-w-max md:min-w-0 leading-5">Delete</button>
+                        <button data-type="select" aria-keyshortcuts="Q" title="Select (Q)" class="shortcut-button bg-gray-500 hover:bg-gray-600 text-white px-3 py-2 rounded-lg text-sm font-medium flex-none min-w-max md:min-w-0 leading-5"><span>Select</span><span class="shortcut-hint" aria-hidden="true">Q</span></button>
+                        <button data-type="move" aria-keyshortcuts="W" title="Pan (W)" class="shortcut-button bg-purple-500 hover:bg-purple-600 text-white px-3 py-2 rounded-lg text-sm font-medium flex-none min-w-max md:min-w-0 leading-5"><span>Pan</span><span class="shortcut-hint" aria-hidden="true">W</span></button>
+                        <button id="deleteButton" data-type="delete" aria-keyshortcuts="E" title="Delete selected; if none selected: Erase mode (E)" class="shortcut-button bg-red-500 hover:bg-red-600 text-white px-3 py-2 rounded-lg text-sm font-medium flex-none min-w-max md:min-w-0 leading-5"><span>Delete</span><span class="shortcut-hint" aria-hidden="true">E</span></button>
                         <button id="clearButton"   class="bg-red-500 hover:bg-red-600 text-white px-3 py-2 rounded-lg text-sm font-medium flex-none min-w-max md:min-w-0 leading-5">Clear</button>
-                        <button id="undoButton"   class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-2 rounded-lg text-sm font-medium flex-none min-w-max md:min-w-0 leading-5" disabled>Undo</button>
-                        <button id="redoButton"   class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-2 rounded-lg text-sm font-medium flex-none min-w-max md:min-w-0 leading-5" disabled>Redo</button>
+                        <button id="undoButton" aria-keyshortcuts="Control+Z,Meta+Z" title="Undo (Ctrl/Cmd+Z)" class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-2 rounded-lg text-sm font-medium flex-none min-w-max md:min-w-0 leading-5" disabled>Undo</button>
+                        <button id="redoButton" aria-keyshortcuts="Control+Y,Meta+Y,Control+Shift+Z,Meta+Shift+Z" title="Redo (Ctrl/Cmd+Y or Ctrl/Cmd+Shift+Z)" class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-2 rounded-lg text-sm font-medium flex-none min-w-max md:min-w-0 leading-5" disabled>Redo</button>
                     </div>
 
                     <div class="h-8 w-px bg-gray-300 hidden md:block"></div>
@@ -44,6 +48,14 @@
                         <button id="centerBtn"    class="h-9 px-3 bg-green-500 hover:bg-green-600 text-white rounded text-xs font-medium">Center</button>
 
                     </div>
+                </div>
+                <div class="hidden md:flex items-center justify-center gap-2 border-t border-gray-200 px-4 py-2 text-xs text-gray-600">
+                    <span><kbd class="rounded border border-gray-300 bg-gray-100 px-1 py-0.5 font-semibold">Q</kbd> Select</span>
+                    <span><kbd class="rounded border border-gray-300 bg-gray-100 px-1 py-0.5 font-semibold">W</kbd> Pan</span>
+                    <span><kbd class="rounded border border-gray-300 bg-gray-100 px-1 py-0.5 font-semibold">E</kbd> Delete/Erase</span>
+                    <span><kbd class="rounded border border-gray-300 bg-gray-100 px-1 py-0.5 font-semibold">1-6</kbd> Buildings</span>
+                    <span><kbd class="rounded border border-gray-300 bg-gray-100 px-1 py-0.5 font-semibold">A</kbd> Alliance</span>
+                    <span><kbd class="rounded border border-gray-300 bg-gray-100 px-1 py-0.5 font-semibold">M</kbd> Mode</span>
                 </div>
             </div>
         </div>
@@ -59,17 +71,17 @@
                        class="w-full p-3 border-2 border-gray-300 rounded-lg text-center focus:border-blue-500 focus:outline-none" maxlength="30">
                 <div id="mapNameHint" class="text-center text-red-500 text-sm mt-1 hidden"></div>
                 <div class="mt-3">
-                    <span class="text-sm font-medium">Mode:</span>
+                    <span class="text-sm font-medium">Mode (M):</span>
                     <div class="mt-1 flex w-full items-center rounded-lg border border-gray-200 bg-gray-100 p-1" role="group" aria-label="Map mode switch">
-                        <button type="button" data-mode="base" aria-pressed="true" class="flex-1 px-3 py-1 text-center text-xs font-medium rounded-md bg-blue-500 text-white shadow-sm transition-colors">Base</button>
-                        <button type="button" data-mode="castle" aria-pressed="false" class="flex-1 px-3 py-1 text-center text-xs font-medium rounded-md bg-transparent text-gray-500 hover:text-gray-700 transition-colors">Castle</button>
+                        <button type="button" data-mode="base" aria-keyshortcuts="M" aria-pressed="true" class="flex-1 px-3 py-1 text-center text-xs font-medium rounded-md bg-blue-500 text-white shadow-sm transition-colors">Base</button>
+                        <button type="button" data-mode="castle" aria-keyshortcuts="M" aria-pressed="false" class="flex-1 px-3 py-1 text-center text-xs font-medium rounded-md bg-transparent text-gray-500 hover:text-gray-700 transition-colors">Castle</button>
                     </div>
                 </div>
                 <div class="mt-2">
-                    <span class="text-sm font-medium">Alliance:</span>
+                    <span class="text-sm font-medium">Alliance (A):</span>
                     <div class="mt-1 flex w-full items-center rounded-lg border border-gray-200 bg-gray-100 p-1" role="group" aria-label="Alliance switch">
-                        <button type="button" data-alliance="main" aria-pressed="true" class="flex-1 px-3 py-1 text-center text-xs font-medium rounded-md bg-blue-500 text-white shadow-sm transition-colors">Main</button>
-                        <button type="button" data-alliance="farm" aria-pressed="false" class="flex-1 px-3 py-1 text-center text-xs font-medium rounded-md bg-transparent text-gray-500 hover:text-gray-700 transition-colors">Farm</button>
+                        <button type="button" data-alliance="main" aria-keyshortcuts="A" aria-pressed="true" class="flex-1 px-3 py-1 text-center text-xs font-medium rounded-md bg-blue-500 text-white shadow-sm transition-colors">Main</button>
+                        <button type="button" data-alliance="farm" aria-keyshortcuts="A" aria-pressed="false" class="flex-1 px-3 py-1 text-center text-xs font-medium rounded-md bg-transparent text-gray-500 hover:text-gray-700 transition-colors">Farm</button>
                     </div>
                 </div>
                     <div id="marchtimeHint" class="mt-2 text-center text-xs text-gray-600 px-3 hidden">
@@ -87,13 +99,13 @@
                     </button>
                     <div id="buildingsSection" class="p-4">
                         <div id="toolbar-buildings" class="grid grid-cols-2 gap-2 mb-4">
-                            <button data-type="flag" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-3 rounded-lg text-sm font-medium">Flag</button>
-                            <button data-type="city" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-3 rounded-lg text-sm font-medium">City</button>
-                            <button data-type="building" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-3 rounded-lg text-sm font-medium">Trap</button>
-                            <button data-type="hq" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-3 rounded-lg text-sm font-medium">HQ</button>
-                            <button data-type="node" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-3 rounded-lg text-sm font-medium">Node</button>
-                            <button data-type="obstacle" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-3 rounded-lg text-sm font-medium">Obstacle</button>
-                            <button data-type="enemyzone" class="bg-gray-700 hover:bg-gray-800 text-white px-4 py-3 rounded-lg text-sm font-medium">Enemy Zone</button>
+                            <button data-type="flag" aria-keyshortcuts="1" title="Flag (1)" class="shortcut-button bg-blue-500 hover:bg-blue-600 text-white px-4 py-3 rounded-lg text-sm font-medium"><span>Flag</span><span class="shortcut-hint" aria-hidden="true">1</span></button>
+                            <button data-type="city" aria-keyshortcuts="2" title="City (2)" class="shortcut-button bg-blue-500 hover:bg-blue-600 text-white px-4 py-3 rounded-lg text-sm font-medium"><span>City</span><span class="shortcut-hint" aria-hidden="true">2</span></button>
+                            <button data-type="building" aria-keyshortcuts="3" title="Trap (3)" class="shortcut-button bg-blue-500 hover:bg-blue-600 text-white px-4 py-3 rounded-lg text-sm font-medium"><span>Trap</span><span class="shortcut-hint" aria-hidden="true">3</span></button>
+                            <button data-type="hq" aria-keyshortcuts="4" title="HQ (4)" class="shortcut-button bg-blue-500 hover:bg-blue-600 text-white px-4 py-3 rounded-lg text-sm font-medium"><span>HQ</span><span class="shortcut-hint" aria-hidden="true">4</span></button>
+                            <button data-type="node" aria-keyshortcuts="5" title="Node (5)" class="shortcut-button bg-blue-500 hover:bg-blue-600 text-white px-4 py-3 rounded-lg text-sm font-medium"><span>Node</span><span class="shortcut-hint" aria-hidden="true">5</span></button>
+                            <button data-type="obstacle" aria-keyshortcuts="6" title="Obstacle (6)" class="shortcut-button bg-blue-500 hover:bg-blue-600 text-white px-4 py-3 rounded-lg text-sm font-medium"><span>Obstacle</span><span class="shortcut-hint" aria-hidden="true">6</span></button>
+                            <button data-type="enemyzone" aria-keyshortcuts="7" title="Enemy Zone (7, Castle mode only)" class="shortcut-button bg-gray-700 hover:bg-gray-800 text-white px-4 py-3 rounded-lg text-sm font-medium"><span>Enemy Zone</span><span class="shortcut-hint" aria-hidden="true">7</span></button>
                         </div>
                         <div class="text-sm p-3 bg-gray-100 rounded-lg text-center space-y-1">
                         <!-- Row 1 -->
@@ -225,7 +237,9 @@
                             <div>
                                 <p class="font-semibold text-green-600 mb-2">Selection & Movement</p>
                                 <p class="ml-2 text-gray-700">• Choose "Select" → tap object</p>
-                                <p class="ml-2 text-gray-700">• Drag to move selected object</p>
+                                <p class="ml-2 text-gray-700">• Ctrl/Cmd+Click adds/removes objects to selection</p>
+                                <p class="ml-2 text-gray-700">• Click+Drag on empty area selects a rectangle</p>
+                                <p class="ml-2 text-gray-700">• Drag a selected object to move the whole selection</p>
                                 <p class="ml-2 text-gray-700">• Type to rename cities</p>
                             </div>
                             <div>
@@ -237,8 +251,18 @@
                             </div>
                             <div>
                                 <p class="font-semibold text-red-600 mb-2">Deletion</p>
-                                <p class="ml-2 text-gray-700">• Select object → Delete button</p>
-                                <p class="ml-2 text-gray-700">• Or use Delete key (desktop)</p>
+                                <p class="ml-2 text-gray-700">• E with selected object: delete selected</p>
+                                <p class="ml-2 text-gray-700">• E with no selection: Erase mode → tap object</p>
+                                <p class="ml-2 text-gray-700">• Delete key removes selected object</p>
+                            </div>
+                            <div>
+                                <p class="font-semibold text-amber-600 mb-2">Keyboard Shortcuts</p>
+                                <p class="ml-2 text-gray-700">• Q = Select, W = Pan, E = Delete selected / Erase mode</p>
+                                <p class="ml-2 text-gray-700">• 1-6 = Flag, City, Trap, HQ, Node, Obstacle</p>
+                                <p class="ml-2 text-gray-700">• 7 = Enemy Zone (Castle mode)</p>
+                                <p class="ml-2 text-gray-700">• M = Toggle Base/Castle mode</p>
+                                <p class="ml-2 text-gray-700">• A = Toggle Main/Farm alliance</p>
+                                <p class="ml-2 text-gray-700">• Ctrl/Cmd+Z = Undo, Ctrl/Cmd+Y = Redo</p>
                             </div>
                             <div class="mt-4 pt-3 border-t border-gray-200">
                                 <p class="text-sm text-gray-500 text-center">
@@ -332,17 +356,17 @@
             <div class="bg-white p-4">
                 <h3 class="font-medium mb-4">Cities</h3>
                 <div class="mb-3">
-                    <span class="text-sm font-medium">Mode:</span>
+                    <span class="text-sm font-medium">Mode (M):</span>
                     <div class="mt-1 flex w-full items-center rounded-lg border border-gray-200 bg-gray-100 p-1" role="group" aria-label="Mobile map mode switch">
-                        <button type="button" data-mode="castle" aria-pressed="false" class="flex-1 px-3 py-1 text-center text-xs font-medium rounded-md bg-transparent text-gray-500 hover:text-gray-700 transition-colors">Castle</button>
-                        <button type="button" data-mode="base" aria-pressed="true" class="flex-1 px-3 py-1 text-center text-xs font-medium rounded-md bg-blue-500 text-white shadow-sm transition-colors">Base</button>
+                        <button type="button" data-mode="castle" aria-keyshortcuts="M" aria-pressed="false" class="flex-1 px-3 py-1 text-center text-xs font-medium rounded-md bg-transparent text-gray-500 hover:text-gray-700 transition-colors">Castle</button>
+                        <button type="button" data-mode="base" aria-keyshortcuts="M" aria-pressed="true" class="flex-1 px-3 py-1 text-center text-xs font-medium rounded-md bg-blue-500 text-white shadow-sm transition-colors">Base</button>
                     </div>
                 </div>
                 <div class="mb-2">
-                    <span class="text-sm font-medium">Alliance:</span>
+                    <span class="text-sm font-medium">Alliance (A):</span>
                     <div class="mt-1 flex w-full items-center rounded-lg border border-gray-200 bg-gray-100 p-1" role="group" aria-label="Mobile alliance switch">
-                        <button type="button" data-alliance="main" aria-pressed="true" class="flex-1 px-3 py-1 text-center text-xs font-medium rounded-md bg-blue-500 text-white shadow-sm transition-colors">Main</button>
-                        <button type="button" data-alliance="farm" aria-pressed="false" class="flex-1 px-3 py-1 text-center text-xs font-medium rounded-md bg-transparent text-gray-500 hover:text-gray-700 transition-colors">Farm</button>
+                        <button type="button" data-alliance="main" aria-keyshortcuts="A" aria-pressed="true" class="flex-1 px-3 py-1 text-center text-xs font-medium rounded-md bg-blue-500 text-white shadow-sm transition-colors">Main</button>
+                        <button type="button" data-alliance="farm" aria-keyshortcuts="A" aria-pressed="false" class="flex-1 px-3 py-1 text-center text-xs font-medium rounded-md bg-transparent text-gray-500 hover:text-gray-700 transition-colors">Farm</button>
                     </div>
                 </div>
                 <div id="mobileActiveAllianceTrapHint" class="mb-3 text-center text-xs text-gray-600">Main traps: 0/2</div>

--- a/layout-planner/index.html
+++ b/layout-planner/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
     <meta property="og:title" content="Alliance Layout Planner">
     <meta property="og:description" content="Check out this Layout!">
     <meta property="og:url" content="https://wosnerds.com/layout-planner/index.html">

--- a/layout-planner/js/script.js
+++ b/layout-planner/js/script.js
@@ -2982,7 +2982,7 @@ function handleInlineEntityNameEditKey(event, key, entity) {
     if (!canInlineEditEntityName(entity)) return false;
     if (event.altKey || event.ctrlKey || event.metaKey) return false;
 
-    if (key === 'Enter' || key === 'Escape') {
+    if (key === 'Enter') {
         event.preventDefault();
         entity.isEditing = false;
         redraw();
@@ -3051,6 +3051,22 @@ function handleKeyDown(event) {
 
     if (singleSelection && (!selectedEntity || !selectedEntities.has(selectedEntity))) {
         selectedEntity = selectedNow[selectedNow.length - 1];
+    }
+
+    if (key === 'Escape' || key === 'Enter' && selectedNow.length) {
+        event.preventDefault();
+        selectedNow.forEach(entity => {
+            if (entity && entity.type === 'city') {
+                entity.isEditing = false;
+            }
+        });
+        clearSelection();
+        isDragging = false;
+        dragSelectionStart = [];
+        hasDragMovement = false;
+        resetBoxSelection();
+        redraw();
+        return;
     }
 
     // Inline rename has priority over plain shortcuts when a single editable entity is selected.

--- a/layout-planner/js/script.js
+++ b/layout-planner/js/script.js
@@ -2974,6 +2974,48 @@ function isPositionValid(newX, newY, entity, ignoreEntities = null) {
     return true;
 }
 
+function canInlineEditEntityName(entity) {
+    return Boolean(entity && entity.type === 'city' && !entity.locked);
+}
+
+function handleInlineEntityNameEditKey(event, key, entity) {
+    if (!canInlineEditEntityName(entity)) return false;
+    if (event.altKey || event.ctrlKey || event.metaKey) return false;
+
+    if (key === 'Enter' || key === 'Escape') {
+        event.preventDefault();
+        entity.isEditing = false;
+        redraw();
+        updateCityList();
+        return true;
+    }
+
+    if (key === 'Backspace') {
+        event.preventDefault();
+        entity.name = entity.name ? entity.name.slice(0, -1) : '';
+        entity.isEditing = true;
+        redraw();
+        updateCityList();
+        markUnsavedChanges();
+        return true;
+    }
+
+    if (key.length === 1) {
+        event.preventDefault();
+        if (!entity.isEditing) {
+            entity.name = '';
+        }
+        entity.isEditing = true;
+        entity.name += key;
+        redraw();
+        updateCityList();
+        markUnsavedChanges();
+        return true;
+    }
+
+    return false;
+}
+
 function handleKeyDown(event) {
     const key = event.key || '';
     const normalizedKey = key.toLowerCase();
@@ -3003,6 +3045,18 @@ function handleKeyDown(event) {
     }
 
     if (isTyping) return;
+
+    const selectedNow = getSelectedEntities();
+    const singleSelection = selectedNow.length === 1;
+
+    if (singleSelection && (!selectedEntity || !selectedEntities.has(selectedEntity))) {
+        selectedEntity = selectedNow[selectedNow.length - 1];
+    }
+
+    // Inline rename has priority over plain shortcuts when a single editable entity is selected.
+    if (singleSelection && handleInlineEntityNameEditKey(event, key, selectedEntity)) {
+        return;
+    }
 
     if (!event.altKey && !event.ctrlKey && !event.metaKey) {
         if (normalizedKey === 'm') {
@@ -3049,7 +3103,6 @@ function handleKeyDown(event) {
         }
     }
 
-    const selectedNow = getSelectedEntities();
     if (!selectedNow.length) return;
 
     if (!selectedEntity || !selectedEntities.has(selectedEntity)) {
@@ -3058,31 +3111,6 @@ function handleKeyDown(event) {
 
     if (isArrowKey) {
         event.preventDefault();
-    }
-
-    const singleSelection = selectedNow.length === 1;
-
-    // City name editing (single selected city only)
-    if (singleSelection &&
-        selectedEntity.type === 'city' &&
-        !['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Delete'].includes(key)
-    ) {
-        if (key === 'Enter') {
-            selectedEntity.isEditing = false;
-        } else if (key === 'Backspace') {
-            event.preventDefault();
-            selectedEntity.name = selectedEntity.name ? selectedEntity.name.slice(0, -1) : '';
-        } else if (key.length === 1) {
-            if (!selectedEntity.isEditing) {
-                selectedEntity.name = '';
-                selectedEntity.isEditing = true;
-            }
-            selectedEntity.name += key;
-        }
-        redraw();
-        updateCityList();
-        markUnsavedChanges();
-        return;
     }
 
     if (key === 'Delete') {

--- a/layout-planner/js/script.js
+++ b/layout-planner/js/script.js
@@ -1664,6 +1664,62 @@ function applyDraggedSelection(deltaX, deltaY) {
     });
 }
 
+function beginSelectionDragFromEntity(clickedEntity, gridPos) {
+    const movableSelection = getSelectedEntities().filter(entity => !entity.locked);
+    if (!movableSelection.length || !movableSelection.includes(clickedEntity)) return;
+
+    isDragging = true;
+    dragOffsetX = gridPos.x;
+    dragOffsetY = gridPos.y;
+    dragSelectionStart = movableSelection.map(entity => ({
+        entity,
+        x: entity.x,
+        y: entity.y
+    }));
+}
+
+function handleSelectEntityClick(clickedEntity, gridPos, { additiveSelection = false } = {}) {
+    if (additiveSelection) {
+        toggleSelection(clickedEntity, { pulseOnAdd: false });
+        redraw();
+        return;
+    }
+
+    const selectedNow = getSelectedEntities();
+    if (!selectedEntities.has(clickedEntity) || selectedNow.length <= 1) {
+        setSelection([clickedEntity], { primaryEntity: clickedEntity, pulse: false });
+    } else {
+        selectedEntity = clickedEntity;
+        stopSelectionPulse();
+    }
+
+    beginSelectionDragFromEntity(clickedEntity, gridPos);
+    redraw();
+}
+
+function handleSelectBlankClick(mouseX, mouseY, { additiveSelection = false } = {}) {
+    startBoxSelection(mouseX, mouseY, { additive: additiveSelection });
+    if (!additiveSelection) {
+        clearSelection();
+    }
+    redraw();
+}
+
+function handleSelectMouseDown(event, mouseX, mouseY) {
+    const gridPos = screenToDiamond(mouseX, mouseY);
+    const clickedEntity = getEntityAtGrid(gridPos.x, gridPos.y);
+    const additiveSelection = event.ctrlKey || event.metaKey;
+
+    hasDragMovement = false;
+    dragSelectionStart = [];
+
+    if (clickedEntity) {
+        handleSelectEntityClick(clickedEntity, gridPos, { additiveSelection });
+    } else {
+        handleSelectBlankClick(mouseX, mouseY, { additiveSelection });
+    }
+}
+
 function handleMouseDown(event) {
     rememberPointerPosition(event.clientX, event.clientY);
     const rect = canvas.getBoundingClientRect();
@@ -1680,65 +1736,34 @@ function handleMouseDown(event) {
         lastMouseX = mouseX;
         lastMouseY = mouseY;
         event.preventDefault();
-    } else if (event.button === 0) { // Left mouse button
-        if (selectedType === 'select') {
-            const gridPos = screenToDiamond(mouseX, mouseY);
-            const clickedEntity = getEntityAtGrid(gridPos.x, gridPos.y);
-            const additiveSelection = event.ctrlKey || event.metaKey;
-
-            hasDragMovement = false;
-            dragSelectionStart = [];
-
-            if (clickedEntity) {
-                if (additiveSelection) {
-                    toggleSelection(clickedEntity, { pulseOnAdd: false });
-                    redraw();
-                    return;
-                }
-
-                const selectedNow = getSelectedEntities();
-                if (!selectedEntities.has(clickedEntity) || selectedNow.length <= 1) {
-                    setSelection([clickedEntity], { primaryEntity: clickedEntity, pulse: false });
-                    redraw();
-                } else {
-                    selectedEntity = clickedEntity;
-                    stopSelectionPulse();
-                    redraw();
-                }
-
-                const movableSelection = getSelectedEntities().filter(entity => !entity.locked);
-                if (movableSelection.length && movableSelection.includes(clickedEntity)) {
-                    isDragging = true;
-                    dragOffsetX = gridPos.x;
-                    dragOffsetY = gridPos.y;
-                    dragSelectionStart = movableSelection.map(entity => ({
-                        entity,
-                        x: entity.x,
-                        y: entity.y
-                    }));
-                }
-            } else {
-                startBoxSelection(mouseX, mouseY, { additive: additiveSelection });
-                if (!additiveSelection) {
-                    clearSelection();
-                }
-                redraw();
-            }
-        } else if (selectedType === 'move') {
-            isPanning = true;
-            lastMouseX = mouseX;
-            lastMouseY = mouseY;
-        } else if (selectedType === 'delete') {
-            flushPendingEraseHistory();
-            hasPendingEraseHistory = false;
-            isErasing = true;
-            if (eraseEntityAtEvent(event, { deferHistory: true })) {
-                hasPendingEraseHistory = true;
-            }
-        } else {
-            addEntity(event);
-        }
+        return;
     }
+
+    if (event.button !== 0) return; // Left mouse button only from here
+
+    if (selectedType === 'select') {
+        handleSelectMouseDown(event, mouseX, mouseY);
+        return;
+    }
+
+    if (selectedType === 'move') {
+        isPanning = true;
+        lastMouseX = mouseX;
+        lastMouseY = mouseY;
+        return;
+    }
+
+    if (selectedType === 'delete') {
+        flushPendingEraseHistory();
+        hasPendingEraseHistory = false;
+        isErasing = true;
+        if (eraseEntityAtEvent(event, { deferHistory: true })) {
+            hasPendingEraseHistory = true;
+        }
+        return;
+    }
+
+    addEntity(event);
 }
 
 function handleMouseMove(event) {

--- a/layout-planner/js/script.js
+++ b/layout-planner/js/script.js
@@ -322,16 +322,6 @@ const wavePalette = [
   '#2dd4bf'  // teal-400
 ];
 
-// ===== TOUCH/MOBILE SUPPORT =====
-let touchStartDistance = 0;
-let initialZoom = 1;
-let touchStartX = 0;
-let touchStartY = 0;
-let touchStartPanX = 0;
-let touchStartPanY = 0;
-let isTouching = false;
-let touchStartTime = 0;
-
 // ===== CANVAS MANAGEMENT =====
 // Initialize canvas size
 function resizeCanvas() {
@@ -2755,134 +2745,6 @@ function updateZoomDisplay() {
     }
 }
 
-function handleTouchStart(event) {
-    event.preventDefault();
-    isTouching = true;
-    touchStartTime = Date.now();
-    
-    const touches = event.touches;
-    
-    if (touches.length === 1) {
-        // Single touch
-        const rect = canvas.getBoundingClientRect();
-        touchStartX = touches[0].clientX - rect.left;
-        touchStartY = touches[0].clientY - rect.top;
-        touchStartPanX = panX;
-        touchStartPanY = panY;
-        
-        if (selectedType === 'select') {
-            selectEntity({ clientX: touches[0].clientX, clientY: touches[0].clientY });
-            if (selectedEntity) {
-                isDragging = true;
-                const gridPos = screenToDiamond(touchStartX, touchStartY);
-                dragOffsetX = gridPos.x - selectedEntity.x;
-                dragOffsetY = gridPos.y - selectedEntity.y;
-            }
-        } else if (selectedType === 'move') {
-            isPanning = true;
-        }
-    } else if (touches.length === 2) {
-        // Two finger touch for pinch zoom
-        const touch1 = touches[0];
-        const touch2 = touches[1];
-        touchStartDistance = Math.sqrt(
-            Math.pow(touch2.clientX - touch1.clientX, 2) +
-            Math.pow(touch2.clientY - touch1.clientY, 2)
-        );
-        initialZoom = zoom;
-        
-        // Center point between fingers
-        const rect = canvas.getBoundingClientRect();
-        touchStartX = ((touch1.clientX + touch2.clientX) / 2) - rect.left;
-        touchStartY = ((touch1.clientY + touch2.clientY) / 2) - rect.top;
-    }
-}
-
-function handleTouchMove(event) {
-    event.preventDefault();
-    const touches = event.touches;
-    
-    if (touches.length === 1 && isTouching) {
-        const rect = canvas.getBoundingClientRect();
-        const currentX = touches[0].clientX - rect.left;
-        const currentY = touches[0].clientY - rect.top;
-        
-        if (isDragging && selectedEntity) {
-            // Move selected entity
-            const gridPos = screenToDiamond(currentX, currentY);
-            const newX = gridPos.x - dragOffsetX;
-            const newY = gridPos.y - dragOffsetY;
-            
-            if (isPositionValid(newX, newY, selectedEntity)) {
-                selectedEntity.x = newX;
-                selectedEntity.y = newY;
-                redraw();
-                markUnsavedChanges();
-            }
-        } else if (isPanning || selectedType === 'move') {
-            // Pan the map
-            panX = touchStartPanX + (currentX - touchStartX);
-            panY = touchStartPanY + (currentY - touchStartY);
-            redraw();
-        } else if (selectedType && selectedType !== 'select' && selectedType !== 'move' && selectedType !== 'delete') {
-            // Update ghost preview
-            updateGhostPreview(currentX, currentY);
-        }
-    } else if (touches.length === 2) {
-        // Pinch zoom
-        const touch1 = touches[0];
-        const touch2 = touches[1];
-        const currentDistance = Math.sqrt(
-            Math.pow(touch2.clientX - touch1.clientX, 2) +
-            Math.pow(touch2.clientY - touch1.clientY, 2)
-        );
-        
-        if (touchStartDistance > 0) {
-            const zoomFactor = currentDistance / touchStartDistance;
-            const newZoom = Math.max(0.1, Math.min(3, initialZoom * zoomFactor));
-            
-            // Zoom towards the center point between fingers
-            const dx = touchStartX - panX;
-            const dy = touchStartY - panY;
-            
-            panX = touchStartX - dx * (newZoom / zoom);
-            panY = touchStartY - dy * (newZoom / zoom);
-            
-            zoom = newZoom;
-            gridSize = baseGridSize * zoom;
-            
-            redraw();
-            updateZoomDisplay();
-        }
-    }
-}
-
-function handleTouchEnd(event) {
-    event.preventDefault();
-    const touchDuration = Date.now() - touchStartTime;
-    
-    if (event.touches.length === 0) {
-        isTouching = false;
-        
-        // Check for tap (short touch duration and minimal movement)
-        if (touchDuration < 300 && !isDragging && !isPanning) {
-            const rect = canvas.getBoundingClientRect();
-            const tapEvent = {
-                clientX: event.changedTouches[0].clientX,
-                clientY: event.changedTouches[0].clientY
-            };
-            
-            if (selectedType && selectedType !== 'select' && selectedType !== 'move' && selectedType !== 'delete') {
-                addEntity(tapEvent);
-            }
-        }
-        
-        isDragging = false;
-        isPanning = false;
-        touchStartDistance = 0;
-    }
-}
-
 function updateGhostPreview(mouseX, mouseY) {
     territoryPreview = null;
 
@@ -4362,101 +4224,177 @@ function exportPlayerNamesCSV({ onlyNamed = false } = {}) {
 }
 
 // ======= Enhanced Mobile Touch (pinch-zoom + one-finger pan) =======
-(function(){
+(function () {
     let touchMode = null; // 'pan' | 'pinch' | null
-    let t0 = null, t1 = null;
-    let startPanX = 0, startPanY = 0;
+    let t0 = null;
+    let t1 = null;
+    let startPanX = 0;
+    let startPanY = 0;
     let startZoom = 1;
     let startDist = 0;
-    let lastCenter = {x: 0, y: 0};
-    let lastTapTime = 0;
+    let startCenterX = 0;
+    let startCenterY = 0;
     let longPressTimer = null;
     const LONG_PRESS_MS = 450;
+    const SELECT_TWO_FINGER_PAN_THRESHOLD = 0.2;
 
-    function getTouches(e){
+    function getTouches(e) {
         const rect = canvas.getBoundingClientRect();
-        const arr = Array.from(e.touches).map(t => ({x: t.clientX - rect.left, y: t.clientY - rect.top, id: t.identifier}));
-        return arr;
+        return Array.from(e.touches).map(t => ({
+            x: t.clientX - rect.left,
+            y: t.clientY - rect.top
+        }));
     }
 
-    function dist(a,b){ const dx=a.x-b.x, dy=a.y-b.y; return Math.hypot(dx,dy); }
-    function mid(a,b){ return { x:(a.x+b.x)/2, y:(a.y+b.y)/2 }; }
+    function dist(a, b) {
+        const dx = a.x - b.x;
+        const dy = a.y - b.y;
+        return Math.hypot(dx, dy);
+    }
 
-    function clearLongPress(){ if (longPressTimer){ clearTimeout(longPressTimer); longPressTimer=null; }}
+    function mid(a, b) {
+        return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+    }
 
-    canvas.addEventListener('touchstart', (e)=>{
-        if (!e.target.closest('#layoutCanvas')) return;
+    function clearLongPress() {
+        if (!longPressTimer) return;
+        clearTimeout(longPressTimer);
+        longPressTimer = null;
+    }
+
+    function resetTouchState() {
+        clearLongPress();
+        touchMode = null;
+        t0 = null;
+        t1 = null;
+    }
+
+    canvas.addEventListener('touchstart', (e) => {
         e.preventDefault();
         const touches = getTouches(e);
 
-        if (touches.length === 1){
-            // single-finger: either tap-to-place/select or drag-to-pan when in Move mode
+        if (touches.length === 1) {
             t0 = touches[0];
             touchMode = 'pan';
             startPanX = panX;
             startPanY = panY;
+            hasDragMovement = false;
+            dragSelectionStart = [];
 
-            // long-press to delete selected entity (mobile shortcut)
+            // Long-press deletes current selection on mobile.
             clearLongPress();
-            longPressTimer = setTimeout(()=>{
-                // If something is selected, delete it
-                if (getSelectedEntities().length){
+            longPressTimer = setTimeout(() => {
+                if (getSelectedEntities().length) {
                     deleteSelectedEntity();
                 }
             }, LONG_PRESS_MS);
 
-            // double-tap to quick zoom in towards tap
-            const now = Date.now();
-            if (now - lastTapTime < 350){
-                const prevZoom = zoom;
-                const newZoom = Math.min(3, zoom * 1.35);
-                const dx = t0.x - panX;
-                const dy = t0.y - panY;
-                panX = t0.x - dx * (newZoom / prevZoom);
-                panY = t0.y - dy * (newZoom / prevZoom);
-                zoom = newZoom;
-                gridSize = baseGridSize * zoom;
-                redraw();
-                updateZoomDisplay();
-            }
-            lastTapTime = now;
+            if (selectedType === 'select') {
+                const gridPos = screenToDiamond(t0.x, t0.y);
+                const touchedEntity = getEntityAtGrid(gridPos.x, gridPos.y);
 
-        } else if (touches.length >= 2){
-            // two-finger pinch
-            t0 = touches[0]; t1 = touches[1];
+                if (touchedEntity) {
+                    const selectedNow = getSelectedEntities();
+                    if (!selectedEntities.has(touchedEntity) || selectedNow.length <= 1) {
+                        setSelection([touchedEntity], { primaryEntity: touchedEntity, pulse: false });
+                    } else {
+                        selectedEntity = touchedEntity;
+                        stopSelectionPulse();
+                    }
+
+                    const movableSelection = getSelectedEntities().filter(entity => !entity.locked);
+                    if (movableSelection.length && movableSelection.includes(touchedEntity)) {
+                        isDragging = true;
+                        dragOffsetX = gridPos.x;
+                        dragOffsetY = gridPos.y;
+                        dragSelectionStart = movableSelection.map(entity => ({
+                            entity,
+                            x: entity.x,
+                            y: entity.y
+                        }));
+                    }
+                } else {
+                    clearSelection();
+                    isDragging = false;
+                    dragSelectionStart = [];
+                }
+                redraw();
+            }
+            return;
+        }
+
+        if (touches.length >= 2) {
+            t0 = touches[0];
+            t1 = touches[1];
             touchMode = 'pinch';
             startZoom = zoom;
             startDist = dist(t0, t1);
-            lastCenter = mid(t0, t1);
+            const startCenter = mid(t0, t1);
+            startCenterX = startCenter.x;
+            startCenterY = startCenter.y;
+            startPanX = panX;
+            startPanY = panY;
         }
-    }, {passive:false});
+    }, { passive: false });
 
-    canvas.addEventListener('touchmove', (e)=>{
-        if (!e.target.closest('#layoutCanvas')) return;
+    canvas.addEventListener('touchmove', (e) => {
         e.preventDefault();
         const touches = getTouches(e);
 
-        if (touchMode === 'pan' && touches.length === 1 && t0){
+        if (touchMode === 'pan' && touches.length === 1 && t0) {
             clearLongPress();
             const cur = touches[0];
-            // If toolbar mode is 'move' OR two-finger initially—pan the map
-            if (selectedType === 'move'){
+
+            if (isDragging && dragSelectionStart.length) {
+                const gridPos = screenToDiamond(cur.x, cur.y);
+                const deltaX = gridPos.x - dragOffsetX;
+                const deltaY = gridPos.y - dragOffsetY;
+
+                if ((deltaX !== 0 || deltaY !== 0) && canMoveDraggedSelection(deltaX, deltaY)) {
+                    applyDraggedSelection(deltaX, deltaY);
+                    hasDragMovement = true;
+                    redraw();
+                    markUnsavedChanges();
+                }
+            } else if (selectedType === 'move') {
                 panX = startPanX + (cur.x - t0.x);
                 panY = startPanY + (cur.y - t0.y);
                 redraw();
-            } else {
-                // show ghost preview while moving single finger
+            } else if (isPlacementTool(selectedType)) {
                 updateGhostPreview(cur.x, cur.y);
                 redraw();
             }
-        } else if (touchMode === 'pinch' && touches.length >= 2){
-            const a = touches[0], b = touches[1];
-            const currDist = dist(a,b);
+            return;
+        }
+
+        if (touchMode === 'pinch' && touches.length >= 2) {
+            const a = touches[0];
+            const b = touches[1];
+            const center = mid(a, b);
+            const currDist = dist(a, b);
             const factor = currDist / (startDist || 1);
+            const pinchDelta = Math.abs(factor - 1);
+
+            // In Pan mode, a two-finger gesture always translates the map.
+            if (selectedType === 'move') {
+                panX = startPanX + (center.x - startCenterX);
+                panY = startPanY + (center.y - startCenterY);
+                redraw();
+                return;
+            }
+
+            // In Select and placement modes, a two-finger swipe (without pinch) pans the map.
+            // Pinch is still available if the distance change is large enough.
+            if ((selectedType === 'select' || isPlacementTool(selectedType)) && pinchDelta < SELECT_TWO_FINGER_PAN_THRESHOLD) {
+                panX = startPanX + (center.x - startCenterX);
+                panY = startPanY + (center.y - startCenterY);
+                redraw();
+                return;
+            }
+
             const newZoom = Math.max(0.1, Math.min(3, startZoom * factor));
 
-            // Zoom around the pinch midpoint
-            const center = mid(a,b);
+            // Zoom around the pinch midpoint.
             const dx = center.x - panX;
             const dy = center.y - panY;
             panX = center.x - dx * (newZoom / zoom);
@@ -4466,22 +4404,28 @@ function exportPlayerNamesCSV({ onlyNamed = false } = {}) {
             redraw();
             updateZoomDisplay();
         }
-    }, {passive:false});
+    }, { passive: false });
 
-    canvas.addEventListener('touchend', (e)=>{
-        if (!e.target.closest('#layoutCanvas')) return;
+    canvas.addEventListener('touchend', (e) => {
         e.preventDefault();
         const touches = getTouches(e);
+        const didEntityDrag = isDragging && hasDragMovement;
 
-        clearLongPress();
+        if (isDragging) {
+            isDragging = false;
+            dragSelectionStart = [];
+            if (hasDragMovement) {
+                pushHistory();
+            }
+            hasDragMovement = false;
+        }
 
-        if (touchMode === 'pan' && (!touches || touches.length === 0) && t0){
-            // Treat as tap if movement was very small
-            const dx = (e.changedTouches[0].clientX - (canvas.getBoundingClientRect().left + t0.x));
-            const dy = (e.changedTouches[0].clientY - (canvas.getBoundingClientRect().top + t0.y));
-            const moved = Math.hypot(dx,dy);
-            if (moved < 8){
-                // Trigger the same logic as a click on canvas (place/select)
+        if (touchMode === 'pan' && (!touches || touches.length === 0) && t0) {
+            // Treat as tap if movement was very small.
+            const dx = e.changedTouches[0].clientX - (canvas.getBoundingClientRect().left + t0.x);
+            const dy = e.changedTouches[0].clientY - (canvas.getBoundingClientRect().top + t0.y);
+            const moved = Math.hypot(dx, dy);
+            if (moved < 8 && !didEntityDrag) {
                 const rect = canvas.getBoundingClientRect();
                 const x = e.changedTouches[0].clientX - rect.left;
                 const y = e.changedTouches[0].clientY - rect.top;
@@ -4489,38 +4433,62 @@ function exportPlayerNamesCSV({ onlyNamed = false } = {}) {
             }
         }
 
-        // reset
-        touchMode = null; t0 = null; t1 = null;
-    }, {passive:false});
+        resetTouchState();
+    }, { passive: false });
 
-    // Centralized handler for canvas tap/click logic (used by both mouse & touch)
+    canvas.addEventListener('touchcancel', () => {
+        resetTouchState();
+    }, { passive: true });
+
+    // Centralized handler for canvas tap/click logic (used by touch).
     function handleCanvasClick(x, y, opts = {}) {
+        const rect = canvas.getBoundingClientRect();
+        const event = { clientX: x + rect.left, clientY: y + rect.top };
+
         if (selectedType === 'select') {
-            // Simulate a selectEntity at (x, y)
-            const rect = canvas.getBoundingClientRect();
-            const event = { clientX: x + rect.left, clientY: y + rect.top };
             selectEntity(event);
         } else if (selectedType === 'delete') {
-            const rect = canvas.getBoundingClientRect();
-            const event = { clientX: x + rect.left, clientY: y + rect.top };
             eraseEntityAtEvent(event);
         } else {
-            // Simulate an addEntity at (x, y)
-            const rect = canvas.getBoundingClientRect();
-            const event = { clientX: x + rect.left, clientY: y + rect.top };
             addEntity(event);
         }
-      // Remove GhostPreview after placement
-      if (opts.fromTouch) {
-        ghostPreview = null;
-        redraw();
-      }
+
+        if (opts.fromTouch) {
+            ghostPreview = null;
+            redraw();
+        }
     }
 
-    // Prevent page bounce/scroll while interacting with canvas
-    document.addEventListener('touchmove', (e)=>{
+    // Prevent page bounce/scroll while interacting with canvas.
+    document.addEventListener('touchmove', (e) => {
         if (e.target === canvas) e.preventDefault();
-    }, {passive:false});
+    }, { passive: false });
+})();
+
+// Fallback guard to prevent browser double-tap zoom on non-interactive surfaces.
+(function () {
+    let lastTouchEndTs = 0;
+    const DOUBLE_TAP_GUARD_MS = 320;
+
+    function shouldBypassDoubleTapGuard(target) {
+        if (!(target instanceof Element)) return false;
+        if (isTextInputTarget(target)) return true;
+        return Boolean(target.closest('button, a, label, summary, [role="button"], [role="tab"], [data-allow-double-tap]'));
+    }
+
+    document.addEventListener('touchend', (e) => {
+        if (e.touches.length > 0 || e.changedTouches.length !== 1) return;
+        if (shouldBypassDoubleTapGuard(e.target)) {
+            lastTouchEndTs = 0;
+            return;
+        }
+
+        const now = Date.now();
+        if (now - lastTouchEndTs < DOUBLE_TAP_GUARD_MS) {
+            e.preventDefault();
+        }
+        lastTouchEndTs = now;
+    }, { passive: false });
 })();
 
 

--- a/layout-planner/js/script.js
+++ b/layout-planner/js/script.js
@@ -94,6 +94,8 @@ let shortcutToastTimerId = null;
 const selectionBoxMinPixels = 4;
 let lastPointerClientX = null;
 let lastPointerClientY = null;
+const KEYBOARD_MOVE_HISTORY_DEBOUNCE_MS = 220;
+let keyboardMoveHistoryTimerId = null;
 
 const TOOL_LABELS = Object.freeze({
     select: 'Select',
@@ -195,6 +197,23 @@ function flushPendingEraseHistory() {
     if (!hasPendingEraseHistory) return;
     pushHistory();
     hasPendingEraseHistory = false;
+}
+
+function flushPendingKeyboardMoveHistory() {
+    if (keyboardMoveHistoryTimerId === null) return;
+    clearTimeout(keyboardMoveHistoryTimerId);
+    keyboardMoveHistoryTimerId = null;
+    pushHistory();
+}
+
+function scheduleKeyboardMoveHistoryPush() {
+    if (keyboardMoveHistoryTimerId !== null) {
+        clearTimeout(keyboardMoveHistoryTimerId);
+    }
+    keyboardMoveHistoryTimerId = window.setTimeout(() => {
+        keyboardMoveHistoryTimerId = null;
+        pushHistory();
+    }, KEYBOARD_MOVE_HISTORY_DEBOUNCE_MS);
 }
 
 function updateCanvasCursorForTool(toolType = selectedType) {
@@ -2894,6 +2913,11 @@ function handleKeyDown(event) {
     const key = event.key || '';
     const normalizedKey = key.toLowerCase();
     const isTyping = isTextInputTarget(event.target);
+    const isArrowKey = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(key);
+
+    if (!isArrowKey) {
+        flushPendingKeyboardMoveHistory();
+    }
 
     // Global Undo/Redo: Ctrl/Cmd+Z, Ctrl/Cmd+Y, Ctrl/Cmd+Shift+Z
     try {
@@ -2967,7 +2991,7 @@ function handleKeyDown(event) {
         selectedEntity = selectedNow[selectedNow.length - 1];
     }
 
-    if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(key)) {
+    if (isArrowKey) {
         event.preventDefault();
     }
 
@@ -3015,18 +3039,6 @@ function handleKeyDown(event) {
 
     if (deltaX === 0 && deltaY === 0) return;
 
-    if (singleSelection) {
-        const newX = selectedEntity.x + deltaX;
-        const newY = selectedEntity.y + deltaY;
-        if (isPositionValid(newX, newY, selectedEntity)) {
-            selectedEntity.x = newX;
-            selectedEntity.y = newY;
-            redraw();
-            markUnsavedChanges();
-        }
-        return;
-    }
-
     const movableSelection = selectedNow.filter(entity => !entity.locked);
     if (!movableSelection.length) return;
     const ignoreEntities = new Set(movableSelection);
@@ -3041,6 +3053,7 @@ function handleKeyDown(event) {
         });
         redraw();
         markUnsavedChanges();
+        scheduleKeyboardMoveHistoryPush();
     }
 }
 

--- a/layout-planner/js/script.js
+++ b/layout-planner/js/script.js
@@ -1846,8 +1846,6 @@ function handleMouseUp(event) {
     if (event.button === 1) {
         isPanning = false;
     } else if (event.button === 0) {
-        isErasing = false;
-        flushPendingEraseHistory();
         if (isBoxSelecting) {
             finalizeBoxSelection();
             return;
@@ -1864,6 +1862,12 @@ function handleMouseUp(event) {
         if (selectedType === 'move') {
             isPanning = false;
         }
+    }
+
+    // this has to be separate to avoid lost undo entries when click-deleting in Delete mode
+    if (isErasing) {
+        isErasing = false;
+        flushPendingEraseHistory();
     }
 }
 
@@ -4713,6 +4717,7 @@ function pushHistory() {
 }
 
 function undo() {
+    flushPendingEraseHistory();
     if (historyIndex <= 0) return;
     historyIndex -= 1;
     applySnapshot(history[historyIndex]);

--- a/layout-planner/js/script.js
+++ b/layout-planner/js/script.js
@@ -16,8 +16,8 @@ const copyShortUrlButton = document.getElementById('copyShortUrlButton');
 const shortUrlContainer = document.getElementById('shortUrlContainer');
 const shortUrlOutput = document.getElementById('shortUrlOutput');
 const shortUrlError = document.getElementById('shortUrlError');
-const deleteButton = document.getElementById('deleteButton');
 const clearButton = document.getElementById('clearButton');
+const eraserCursor = document.getElementById('eraserCursor');
 
 // ===== GRID CONFIGURATION =====
 const baseGridSize = 30;
@@ -37,6 +37,7 @@ const defaultCityLabelMode = "march";
 const defaultWaveMode = false;
 let selectedType = null;
 let selectedEntity = null;
+let selectedEntities = new Set();
 let cityCounterId = 1;
 let bearTraps = [];
 let enemyZones = []; // Array for enemy zones (max 3)
@@ -64,9 +65,16 @@ function initializeDefaultTeams() {
 }
 
 let isDragging = false;
+let isErasing = false;
 let isPanning = false;
 let dragOffsetX = 0;
 let dragOffsetY = 0;
+let dragSelectionStart = [];
+let hasDragMovement = false;
+let isBoxSelecting = false;
+let selectionBoxStart = null;
+let selectionBoxCurrent = null;
+let selectionBoxAdditive = false;
 let lastMouseX = 0;
 let lastMouseY = 0;
 let hasUnsavedChanges = false;
@@ -81,6 +89,138 @@ const castleRedzoneThickness = 8; // Thickness of the redzone ring around the re
 const selectionPulseDurationMs = 1400;
 let selectionPulseActiveUntil = 0;
 let selectionPulseRafId = null;
+let shortcutToastTimerId = null;
+const selectionBoxMinPixels = 4;
+let lastPointerClientX = null;
+let lastPointerClientY = null;
+
+const TOOL_LABELS = Object.freeze({
+    select: 'Select',
+    move: 'Pan',
+    delete: 'Erase',
+    flag: 'Flag',
+    city: 'City',
+    building: 'Trap',
+    hq: 'HQ',
+    node: 'Node',
+    obstacle: 'Obstacle',
+    enemyzone: 'Enemy Zone'
+});
+
+const TOOL_SHORTCUT_LABELS = Object.freeze({
+    select: 'Q',
+    move: 'W',
+    delete: 'E',
+    flag: '1',
+    city: '2',
+    building: '3',
+    hq: '4',
+    node: '5',
+    obstacle: '6',
+    enemyzone: '7'
+});
+
+const TOOL_SHORTCUT_KEY_MAP = Object.freeze({
+    q: 'select',
+    w: 'move',
+    '1': 'flag',
+    '2': 'city',
+    '3': 'building',
+    '4': 'hq',
+    '5': 'node',
+    '6': 'obstacle',
+    '7': 'enemyzone'
+});
+
+function isTextInputTarget(target) {
+    if (!(target instanceof Element)) return false;
+    if (target.isContentEditable) return true;
+    return Boolean(target.closest('input, textarea, select, [contenteditable="true"], [role="textbox"]'));
+}
+
+function setEraserCursorVisible(isVisible) {
+    if (!eraserCursor) return;
+    eraserCursor.classList.toggle('visible', Boolean(isVisible));
+}
+
+function rememberPointerPosition(clientX, clientY) {
+    if (typeof clientX !== 'number' || typeof clientY !== 'number') return;
+    lastPointerClientX = clientX;
+    lastPointerClientY = clientY;
+}
+
+function updateEraserCursorPosition(clientX, clientY) {
+    if (!eraserCursor || typeof clientX !== 'number' || typeof clientY !== 'number') return;
+    eraserCursor.style.left = `${clientX}px`;
+    eraserCursor.style.top = `${clientY}px`;
+}
+
+function isPlacementTool(toolType = selectedType) {
+    return Boolean(toolType && toolType !== 'select' && toolType !== 'move' && toolType !== 'delete');
+}
+
+function refreshGhostPreviewForCurrentPointer(toolType = selectedType) {
+    if (!isPlacementTool(toolType)) return;
+    if (!canvas.matches(':hover')) return;
+    if (lastPointerClientX === null || lastPointerClientY === null) return;
+
+    const rect = canvas.getBoundingClientRect();
+    const mouseX = lastPointerClientX - rect.left;
+    const mouseY = lastPointerClientY - rect.top;
+    updateGhostPreview(mouseX, mouseY);
+}
+
+function refreshEraserCursorForCurrentPointer(toolType = selectedType) {
+    if (toolType !== 'delete') {
+        setEraserCursorVisible(false);
+        return;
+    }
+
+    if (!canvas.matches(':hover')) {
+        setEraserCursorVisible(false);
+        return;
+    }
+
+    if (lastPointerClientX === null || lastPointerClientY === null) {
+        const rect = canvas.getBoundingClientRect();
+        updateEraserCursorPosition(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    } else {
+        updateEraserCursorPosition(lastPointerClientX, lastPointerClientY);
+    }
+    setEraserCursorVisible(true);
+}
+
+function updateCanvasCursorForTool(toolType = selectedType) {
+    canvas.classList.toggle('eraser-cursor-active', toolType === 'delete');
+
+    if (toolType === 'move') {
+        canvas.style.cursor = 'move';
+    } else if (toolType === 'delete') {
+        canvas.style.cursor = 'none';
+    } else if (toolType === 'select') {
+        canvas.style.cursor = 'pointer';
+    } else {
+        canvas.style.cursor = 'crosshair';
+    }
+
+    refreshEraserCursorForCurrentPointer(toolType);
+}
+
+function showShortcutToast(message, timeoutMs = 950) {
+    const toast = document.getElementById('shortcutToast');
+    if (!toast || !message) return;
+
+    toast.textContent = message;
+    toast.classList.add('visible');
+
+    if (shortcutToastTimerId !== null) {
+        clearTimeout(shortcutToastTimerId);
+    }
+    shortcutToastTimerId = setTimeout(() => {
+        toast.classList.remove('visible');
+        shortcutToastTimerId = null;
+    }, timeoutMs);
+}
 
 function normalizeAllianceId(allianceId) {
     return ALLIANCES.some(a => a.id === allianceId) ? allianceId : DEFAULT_ALLIANCE_ID;
@@ -444,9 +584,6 @@ function drawEntities(context, pX, pY, z) {
     entities.forEach(entity => {
         drawEntity(context, pX, pY, z, entity, protectedAreasByAlliance);
         
-        if (selectedEntity === entity) {
-            drawSelectionHighlight(context, pX, pY, z, entity);
-        }
     });
     
     // Draw ghost preview if applicable
@@ -455,8 +592,12 @@ function drawEntities(context, pX, pY, z) {
     }
 
     // Always draw selection as the top-most layer for better visibility.
-    if (selectedEntity && entities.includes(selectedEntity)) {
-        drawSelectionHighlight(context, pX, pY, z, selectedEntity);
+    getSelectedEntities().forEach(entity => {
+        drawSelectionHighlight(context, pX, pY, z, entity);
+    });
+
+    if (isBoxSelecting && selectionBoxStart && selectionBoxCurrent) {
+        drawSelectionMarquee(context);
     }
 }
 
@@ -822,6 +963,24 @@ function drawSelectionHighlight(context, pX, pY, z, entity) {
     context.restore();
 }
 
+function drawSelectionMarquee(context) {
+    if (!selectionBoxStart || !selectionBoxCurrent) return;
+
+    const x = Math.min(selectionBoxStart.x, selectionBoxCurrent.x);
+    const y = Math.min(selectionBoxStart.y, selectionBoxCurrent.y);
+    const width = Math.abs(selectionBoxCurrent.x - selectionBoxStart.x);
+    const height = Math.abs(selectionBoxCurrent.y - selectionBoxStart.y);
+
+    context.save();
+    context.fillStyle = 'rgba(59, 130, 246, 0.15)';
+    context.strokeStyle = 'rgba(59, 130, 246, 0.95)';
+    context.lineWidth = 1.5;
+    context.setLineDash([6, 4]);
+    context.fillRect(x, y, width, height);
+    context.strokeRect(x, y, width, height);
+    context.restore();
+}
+
 function calculateMarchTimes(city) {
     // Castle time at 25% speed bonus
     if (mapMode === 'castle') {
@@ -1066,7 +1225,7 @@ function drawAnchorSymbol(context, pX, pY, z) {
 
 // ===== ENTITY PLACEMENT =====
 function addEntity(event) {
-    if (!selectedType || selectedType === 'select') return;
+    if (!selectedType || selectedType === 'select' || selectedType === 'move' || selectedType === 'delete') return;
 
     const rect = canvas.getBoundingClientRect();
     const mouseX = event.clientX - rect.left;
@@ -1181,27 +1340,224 @@ function startSelectionPulse(durationMs = selectionPulseDurationMs) {
     selectionPulseRafId = requestAnimationFrame(animatePulse);
 }
 
-function selectEntity(event) {
-    if (selectedType !== 'select') return;
+function getSelectedEntities() {
+    const validSelection = [];
+    selectedEntities.forEach(entity => {
+        if (entities.includes(entity)) {
+            validSelection.push(entity);
+        }
+    });
+
+    if (validSelection.length !== selectedEntities.size) {
+        selectedEntities = new Set(validSelection);
+    }
+
+    if (selectedEntity && !selectedEntities.has(selectedEntity)) {
+        selectedEntity = validSelection.length ? validSelection[validSelection.length - 1] : null;
+    }
+
+    return validSelection;
+}
+
+function clearSelection({ stopPulse = true } = {}) {
+    selectedEntities.clear();
+    selectedEntity = null;
+    if (stopPulse) {
+        stopSelectionPulse();
+    }
+}
+
+function setSelection(entitiesToSelect = [], { primaryEntity = null, pulse = false } = {}) {
+    const validSelection = entitiesToSelect.filter(entity => entity && entities.includes(entity));
+    selectedEntities = new Set(validSelection);
+
+    if (!validSelection.length) {
+        selectedEntity = null;
+        stopSelectionPulse();
+        return;
+    }
+
+    if (primaryEntity && selectedEntities.has(primaryEntity)) {
+        selectedEntity = primaryEntity;
+    } else {
+        selectedEntity = validSelection[validSelection.length - 1];
+    }
+
+    if (pulse) {
+        startSelectionPulse();
+    } else {
+        stopSelectionPulse();
+    }
+}
+
+function addToSelection(entity, { makePrimary = true, pulse = false } = {}) {
+    if (!entity || !entities.includes(entity)) return;
+    const currentSelection = getSelectedEntities();
+    if (!selectedEntities.has(entity)) {
+        currentSelection.push(entity);
+    }
+    setSelection(currentSelection, { primaryEntity: makePrimary ? entity : selectedEntity, pulse });
+}
+
+function removeFromSelection(entity) {
+    if (!entity || !selectedEntities.has(entity)) return;
+    const remainingSelection = getSelectedEntities().filter(item => item !== entity);
+    const nextPrimary = selectedEntity === entity ? remainingSelection[remainingSelection.length - 1] : selectedEntity;
+    setSelection(remainingSelection, { primaryEntity: nextPrimary, pulse: false });
+}
+
+function toggleSelection(entity, { pulseOnAdd = true } = {}) {
+    if (!entity) return;
+    if (selectedEntities.has(entity)) {
+        removeFromSelection(entity);
+    } else {
+        addToSelection(entity, { makePrimary: true, pulse: pulseOnAdd });
+    }
+}
+
+function getEntityAtGrid(gridX, gridY) {
+    for (let i = entities.length - 1; i >= 0; i--) {
+        const entity = entities[i];
+        if (
+            gridX >= entity.x &&
+            gridX < entity.x + entity.width &&
+            gridY >= entity.y &&
+            gridY < entity.y + entity.height
+        ) {
+            return entity;
+        }
+    }
+    return null;
+}
+
+function getSelectionBoxRect() {
+    if (!selectionBoxStart || !selectionBoxCurrent) return null;
+
+    const x = Math.min(selectionBoxStart.x, selectionBoxCurrent.x);
+    const y = Math.min(selectionBoxStart.y, selectionBoxCurrent.y);
+    const width = Math.abs(selectionBoxCurrent.x - selectionBoxStart.x);
+    const height = Math.abs(selectionBoxCurrent.y - selectionBoxStart.y);
+
+    return { x, y, width, height };
+}
+
+function getEntitiesInSelectionBox(rect) {
+    if (!rect) return [];
+
+    const right = rect.x + rect.width;
+    const bottom = rect.y + rect.height;
+
+    return entities.filter(entity => {
+        const topLeft = diamondToScreenCorner(entity.x, entity.y, panX, panY, zoom);
+        const topRight = diamondToScreenCorner(entity.x + entity.width, entity.y, panX, panY, zoom);
+        const bottomLeft = diamondToScreenCorner(entity.x, entity.y + entity.height, panX, panY, zoom);
+        const bottomRight = diamondToScreenCorner(entity.x + entity.width, entity.y + entity.height, panX, panY, zoom);
+
+        const minX = Math.min(topLeft.x, topRight.x, bottomLeft.x, bottomRight.x);
+        const maxX = Math.max(topLeft.x, topRight.x, bottomLeft.x, bottomRight.x);
+        const minY = Math.min(topLeft.y, topRight.y, bottomLeft.y, bottomRight.y);
+        const maxY = Math.max(topLeft.y, topRight.y, bottomLeft.y, bottomRight.y);
+
+        return !(maxX < rect.x || minX > right || maxY < rect.y || minY > bottom);
+    });
+}
+
+function startBoxSelection(mouseX, mouseY, { additive = false } = {}) {
+    isBoxSelecting = true;
+    selectionBoxAdditive = additive;
+    selectionBoxStart = { x: mouseX, y: mouseY };
+    selectionBoxCurrent = { x: mouseX, y: mouseY };
+}
+
+function updateBoxSelection(mouseX, mouseY) {
+    if (!isBoxSelecting) return;
+    selectionBoxCurrent = { x: mouseX, y: mouseY };
+}
+
+function resetBoxSelection() {
+    isBoxSelecting = false;
+    selectionBoxStart = null;
+    selectionBoxCurrent = null;
+    selectionBoxAdditive = false;
+}
+
+function finalizeBoxSelection() {
+    if (!isBoxSelecting) return;
+
+    const rect = getSelectionBoxRect();
+    const isDragSelection = rect && (rect.width >= selectionBoxMinPixels || rect.height >= selectionBoxMinPixels);
+
+    if (!isDragSelection) {
+        if (!selectionBoxAdditive) {
+            clearSelection();
+        }
+        resetBoxSelection();
+        redraw();
+        return;
+    }
+
+    const boxEntities = getEntitiesInSelectionBox(rect);
+    if (selectionBoxAdditive) {
+        const merged = new Set(getSelectedEntities());
+        boxEntities.forEach(entity => merged.add(entity));
+        const mergedArray = Array.from(merged);
+        setSelection(mergedArray, {
+            primaryEntity: boxEntities[boxEntities.length - 1] || selectedEntity,
+            pulse: false
+        });
+    } else {
+        setSelection(boxEntities, {
+            primaryEntity: boxEntities[boxEntities.length - 1] || null,
+            pulse: false
+        });
+    }
+
+    resetBoxSelection();
+    redraw();
+}
+
+function selectEntity(event, { additive = false, toggle = false, pulse = false } = {}) {
+    if (selectedType !== 'select') return null;
 
     const rect = canvas.getBoundingClientRect();
     const mouseX = event.clientX - rect.left;
     const mouseY = event.clientY - rect.top;
-    
     const gridPos = screenToDiamond(mouseX, mouseY);
+    const clickedEntity = getEntityAtGrid(gridPos.x, gridPos.y);
 
-    const clickedEntity = entities.find(entity => {
-        return (
-            gridPos.x >= entity.x &&
-            gridPos.x < entity.x + entity.width &&
-            gridPos.y >= entity.y &&
-            gridPos.y < entity.y + entity.height
-        );
-    });
+    if (!clickedEntity) {
+        if (!additive && !toggle) {
+            clearSelection();
+        }
+        redraw();
+        return null;
+    }
 
-    selectedEntity = clickedEntity || null;
-    stopSelectionPulse();
+    if (toggle || additive) {
+        toggleSelection(clickedEntity, { pulseOnAdd: pulse });
+    } else {
+        setSelection([clickedEntity], { primaryEntity: clickedEntity, pulse });
+    }
+
     redraw();
+    return clickedEntity;
+}
+
+function eraseEntityAtEvent(event) {
+    if (selectedType !== 'delete') return false;
+
+    const rect = canvas.getBoundingClientRect();
+    const mouseX = event.clientX - rect.left;
+    const mouseY = event.clientY - rect.top;
+    const gridPos = screenToDiamond(mouseX, mouseY);
+    const clickedEntity = getEntityAtGrid(gridPos.x, gridPos.y);
+
+    if (!clickedEntity || clickedEntity.locked) {
+        return false;
+    }
+
+    setSelection([clickedEntity], { primaryEntity: clickedEntity, pulse: false });
+    return deleteSelectedEntity() > 0;
 }
 
 // ===== INPUT HANDLING =====
@@ -1276,10 +1632,32 @@ function centerMap() {
     redraw();
 }
 
+function canMoveDraggedSelection(deltaX, deltaY) {
+    if (!dragSelectionStart.length) return false;
+    const ignoreEntities = new Set(dragSelectionStart.map(item => item.entity));
+
+    return dragSelectionStart.every(item =>
+        isPositionValid(item.x + deltaX, item.y + deltaY, item.entity, ignoreEntities)
+    );
+}
+
+function applyDraggedSelection(deltaX, deltaY) {
+    dragSelectionStart.forEach(item => {
+        item.entity.x = item.x + deltaX;
+        item.entity.y = item.y + deltaY;
+    });
+}
+
 function handleMouseDown(event) {
+    rememberPointerPosition(event.clientX, event.clientY);
     const rect = canvas.getBoundingClientRect();
     const mouseX = event.clientX - rect.left;
     const mouseY = event.clientY - rect.top;
+
+    if (selectedType === 'delete') {
+        updateEraserCursorPosition(event.clientX, event.clientY);
+        setEraserCursorVisible(true);
+    }
     
     if (event.button === 1) { // Middle mouse button
         isPanning = true;
@@ -1288,17 +1666,55 @@ function handleMouseDown(event) {
         event.preventDefault();
     } else if (event.button === 0) { // Left mouse button
         if (selectedType === 'select') {
-            selectEntity(event);
-            if (selectedEntity && !selectedEntity.locked) {
-                isDragging = true;
-                const gridPos = screenToDiamond(mouseX, mouseY);
-                dragOffsetX = gridPos.x - selectedEntity.x;
-                dragOffsetY = gridPos.y - selectedEntity.y;
+            const gridPos = screenToDiamond(mouseX, mouseY);
+            const clickedEntity = getEntityAtGrid(gridPos.x, gridPos.y);
+            const additiveSelection = event.ctrlKey || event.metaKey;
+
+            hasDragMovement = false;
+            dragSelectionStart = [];
+
+            if (clickedEntity) {
+                if (additiveSelection) {
+                    toggleSelection(clickedEntity, { pulseOnAdd: false });
+                    redraw();
+                    return;
+                }
+
+                const selectedNow = getSelectedEntities();
+                if (!selectedEntities.has(clickedEntity) || selectedNow.length <= 1) {
+                    setSelection([clickedEntity], { primaryEntity: clickedEntity, pulse: false });
+                    redraw();
+                } else {
+                    selectedEntity = clickedEntity;
+                    stopSelectionPulse();
+                    redraw();
+                }
+
+                const movableSelection = getSelectedEntities().filter(entity => !entity.locked);
+                if (movableSelection.length && movableSelection.includes(clickedEntity)) {
+                    isDragging = true;
+                    dragOffsetX = gridPos.x;
+                    dragOffsetY = gridPos.y;
+                    dragSelectionStart = movableSelection.map(entity => ({
+                        entity,
+                        x: entity.x,
+                        y: entity.y
+                    }));
+                }
+            } else {
+                startBoxSelection(mouseX, mouseY, { additive: additiveSelection });
+                if (!additiveSelection) {
+                    clearSelection();
+                }
+                redraw();
             }
         } else if (selectedType === 'move') {
             isPanning = true;
             lastMouseX = mouseX;
             lastMouseY = mouseY;
+        } else if (selectedType === 'delete') {
+            isErasing = true;
+            eraseEntityAtEvent(event);
         } else {
             addEntity(event);
         }
@@ -1306,9 +1722,15 @@ function handleMouseDown(event) {
 }
 
 function handleMouseMove(event) {
+    rememberPointerPosition(event.clientX, event.clientY);
     const rect = canvas.getBoundingClientRect();
     const mouseX = event.clientX - rect.left;
     const mouseY = event.clientY - rect.top;
+
+    if (selectedType === 'delete') {
+        updateEraserCursorPosition(event.clientX, event.clientY);
+        setEraserCursorVisible(true);
+    }
     
     if (isPanning) {
         panX += mouseX - lastMouseX;
@@ -1316,14 +1738,19 @@ function handleMouseMove(event) {
         lastMouseX = mouseX;
         lastMouseY = mouseY;
         redraw();
-    } else if (isDragging && selectedEntity) {
+    } else if (isBoxSelecting) {
+        updateBoxSelection(mouseX, mouseY);
+        redraw();
+    } else if (isErasing && selectedType === 'delete') {
+        eraseEntityAtEvent(event);
+    } else if (isDragging && dragSelectionStart.length) {
         const gridPos = screenToDiamond(mouseX, mouseY);
-        const newX = gridPos.x - dragOffsetX;
-        const newY = gridPos.y - dragOffsetY;
-        
-        if (isPositionValid(newX, newY, selectedEntity)) {
-            selectedEntity.x = newX;
-            selectedEntity.y = newY;
+        const deltaX = gridPos.x - dragOffsetX;
+        const deltaY = gridPos.y - dragOffsetY;
+
+        if ((deltaX !== 0 || deltaY !== 0) && canMoveDraggedSelection(deltaX, deltaY)) {
+            applyDraggedSelection(deltaX, deltaY);
+            hasDragMovement = true;
             redraw();
             markUnsavedChanges();
         }
@@ -1336,10 +1763,19 @@ function handleMouseUp(event) {
     if (event.button === 1) {
         isPanning = false;
     } else if (event.button === 0) {
-        // If we finished dragging an entity, snapshot the new state
+        isErasing = false;
+        if (isBoxSelecting) {
+            finalizeBoxSelection();
+            return;
+        }
+
         if (isDragging) {
             isDragging = false;
-            pushHistory();
+            dragSelectionStart = [];
+            if (hasDragMovement) {
+                pushHistory();
+            }
+            hasDragMovement = false;
         }
         if (selectedType === 'move') {
             isPanning = false;
@@ -1349,48 +1785,75 @@ function handleMouseUp(event) {
 
 // Update this function to handle both desktop and mobile toolbars
 function handleToolbarClick(e) {
+    const button = e.target instanceof Element ? e.target.closest('button') : null;
+    if (!button) return;
+
     // Handle map-mode toggles (e.g. Castle)
-    if (e.target.dataset.mode) {
-        setMapMode(e.target.dataset.mode);
+    if (button.dataset.mode) {
+        setMapMode(button.dataset.mode);
         return;
     }
 
-    if (e.target.dataset.type) {
-        selectedType = e.target.dataset.type;
-        selectedEntity = null; // Deselect any entity when changing tools
-        stopSelectionPulse();
-        
-        // Remove highlighting from all buttons in both toolbars
-        document.querySelectorAll('#toolbar-controls button, #toolbar-buildings button, #mobile-toolbar-buildings button').forEach(button => {
-            button.classList.remove('bg-yellow-500', 'bg-yellow-600');
-            
-            // Restore original colors for non-selected buttons
-            if (button.dataset.type === e.target.dataset.type) {
-                button.classList.add('bg-yellow-500');
-            } else {
-                if (button.dataset.type === 'flag') button.classList.add('bg-blue-500');
-                if (button.dataset.type === 'city') button.classList.add('bg-blue-500');
-                if (button.dataset.type === 'building') button.classList.add('bg-blue-500');
-                if (button.dataset.type === 'node') button.classList.add('bg-blue-500');
-                if (button.dataset.type === 'hq') button.classList.add('bg-blue-500');
-                if (button.dataset.type === 'obstacle') button.classList.add('bg-blue-500');
-            }
-        });
-        
-        if ((selectedType === 'select' || selectedType === 'move') && ghostPreview) {
-            ghostPreview = null;
-        }
-        redraw(); // Redraw to remove selection highlight
-        
-        // Update cursor style
-        if (selectedType === 'move') {
-            canvas.style.cursor = 'move';
-        } else if (selectedType === 'select') {
-            canvas.style.cursor = 'pointer';
+    if (button.dataset.type === 'delete') {
+        if (getSelectedEntities().length) {
+            const deletedCount = deleteSelectedEntity();
+            showShortcutToast(
+                deletedCount > 0
+                    ? `Deleted ${deletedCount === 1 ? 'selected entity' : `${deletedCount} entities`} (E)`
+                    : 'Selected object cannot be deleted'
+            );
         } else {
-            canvas.style.cursor = 'crosshair';
+            setSelectedTool('delete', { showToast: true });
         }
+        return;
     }
+
+    if (button.dataset.type) {
+        setSelectedTool(button.dataset.type);
+    }
+}
+
+function setSelectedTool(toolType, { showToast = false } = {}) {
+    if (!toolType) return false;
+
+    const knownToolButton = document.querySelector(
+        `#toolbar-controls button[data-type="${toolType}"], #toolbar-buildings button[data-type="${toolType}"], #mobile-toolbar-buildings button[data-type="${toolType}"]`
+    );
+    if (!knownToolButton) return false;
+
+    selectedType = toolType;
+    clearSelection();
+    isErasing = false;
+    isDragging = false;
+    dragSelectionStart = [];
+    hasDragMovement = false;
+    resetBoxSelection();
+    stopSelectionPulse();
+
+    document.querySelectorAll('#toolbar-controls button[data-type], #toolbar-buildings button[data-type], #mobile-toolbar-buildings button[data-type]').forEach(button => {
+        button.classList.remove('bg-yellow-500', 'bg-yellow-600');
+
+        if (button.dataset.type === toolType) {
+            button.classList.add('bg-yellow-500');
+        } else if (['flag', 'city', 'building', 'node', 'hq', 'obstacle'].includes(button.dataset.type)) {
+            button.classList.add('bg-blue-500');
+        }
+    });
+
+    if ((selectedType === 'select' || selectedType === 'move' || selectedType === 'delete') && ghostPreview) {
+        ghostPreview = null;
+    }
+    redraw();
+    updateCanvasCursorForTool(toolType);
+    refreshGhostPreviewForCurrentPointer(toolType);
+
+    if (showToast) {
+        const shortcut = TOOL_SHORTCUT_LABELS[toolType];
+        const label = TOOL_LABELS[toolType] || toolType;
+        showShortcutToast(shortcut ? `${label} (${shortcut})` : label);
+    }
+
+    return true;
 }
 
 // ===== SET/RENDER GUI BUTTONS =====
@@ -1483,11 +1946,9 @@ function updateEnemyZoneButtonVisibility() {
     });
 
     if (!show && selectedType === 'enemyzone') {
-        const selectButton = document.querySelector('[data-type="select"]');
-        if (selectButton) {
-            selectButton.click();
-        } else {
+        if (!setSelectedTool('select')) {
             selectedType = 'select';
+            updateCanvasCursorForTool('select');
         }
     }
 }
@@ -1747,13 +2208,21 @@ window.addEventListener('DOMContentLoaded', () => {
 
 window.addEventListener('resize', resizeCanvas);
 window.addEventListener('keydown', handleKeyDown);
+window.addEventListener('mouseup', handleMouseUp);
 
 canvas.addEventListener('wheel', handleWheel);
 canvas.addEventListener('mousedown', handleMouseDown);
 canvas.addEventListener('mousemove', handleMouseMove);
 canvas.addEventListener('mouseup', handleMouseUp);
+canvas.addEventListener('mouseenter', (event) => {
+    rememberPointerPosition(event.clientX, event.clientY);
+    refreshEraserCursorForCurrentPointer(selectedType);
+    refreshGhostPreviewForCurrentPointer(selectedType);
+});
 canvas.addEventListener('contextmenu', (e) => e.preventDefault());
 canvas.addEventListener('mouseleave', () => {
+    isErasing = false;
+    setEraserCursorVisible(false);
     // Clear ghost preview when mouse leaves canvas
     if (ghostPreview) {
         ghostPreview = null;
@@ -1789,6 +2258,7 @@ window.addEventListener('DOMContentLoaded', () => {
     // Initialize mode/alliance switch visuals
     setMapMode(mapMode);
     setActiveAlliance(activeAllianceId);
+    setSelectedTool(selectedType || 'select');
 
     // Add zoom control event listeners
     document.getElementById('zoomInBtn')?.addEventListener('click', zoomIn);
@@ -1912,14 +2382,6 @@ window.addEventListener('DOMContentLoaded', () => {
         document.getElementById(`${prefix}downloadButton`)?.addEventListener('click', downloadCanvasAsPNG);
     });
     
-    deleteButton.addEventListener('click', () => {
-        if (selectedEntity) {
-            deleteSelectedEntity();
-        } else {
-            alert('No entity selected to delete.');
-        }
-    });
-    
     // Clear the entire map but preserve locked entities (e.g., castle/turrets)
     clearButton.addEventListener('click', () => {
         if (confirm('Are you sure you want to clear the entire map?')) {
@@ -1932,8 +2394,7 @@ window.addEventListener('DOMContentLoaded', () => {
             bearTraps.length = 0;
             enemyZones.length = 0;
             cityCounterId = 1;
-            selectedEntity = null;
-            stopSelectionPulse();
+            clearSelection();
 
             redraw();
             updateCounters();
@@ -2348,7 +2809,7 @@ function handleTouchMove(event) {
             panX = touchStartPanX + (currentX - touchStartX);
             panY = touchStartPanY + (currentY - touchStartY);
             redraw();
-        } else if (selectedType && selectedType !== 'select' && selectedType !== 'move') {
+        } else if (selectedType && selectedType !== 'select' && selectedType !== 'move' && selectedType !== 'delete') {
             // Update ghost preview
             updateGhostPreview(currentX, currentY);
         }
@@ -2396,7 +2857,7 @@ function handleTouchEnd(event) {
                 clientY: event.changedTouches[0].clientY
             };
             
-            if (selectedType && selectedType !== 'select' && selectedType !== 'move') {
+            if (selectedType && selectedType !== 'select' && selectedType !== 'move' && selectedType !== 'delete') {
                 addEntity(tapEvent);
             }
         }
@@ -2410,7 +2871,7 @@ function handleTouchEnd(event) {
 function updateGhostPreview(mouseX, mouseY) {
     territoryPreview = null;
 
-    if (selectedType && selectedType !== 'select' && selectedType !== 'move') {
+    if (selectedType && selectedType !== 'select' && selectedType !== 'move' && selectedType !== 'delete') {
         const gridPos = screenToDiamond(mouseX, mouseY);
         const x = gridPos.x;
         const y = gridPos.y;
@@ -2469,7 +2930,7 @@ function isProtectedSourceInsideForeignProtectedArea(newX, newY, entity) {
     return false;
 }
 
-function isPositionValid(newX, newY, entity) {
+function isPositionValid(newX, newY, entity, ignoreEntities = null) {
     if (newX < -gridCols || newX + entity.width > gridCols + 1 || 
         newY < -gridRows || newY + entity.height > gridRows + 1) {
         return false;
@@ -2537,6 +2998,7 @@ function isPositionValid(newX, newY, entity) {
     
     for (let other of entities) {
         if (other !== entity) {
+            if (ignoreEntities && ignoreEntities.has(other)) continue;
             const hasOverlap =
                 newX < other.x + other.width &&
                 newX + entity.width > other.x &&
@@ -2552,16 +3014,20 @@ function isPositionValid(newX, newY, entity) {
 }
 
 function handleKeyDown(event) {
+    const key = event.key || '';
+    const normalizedKey = key.toLowerCase();
+    const isTyping = isTextInputTarget(event.target);
+
     // Global Undo/Redo: Ctrl/Cmd+Z, Ctrl/Cmd+Y, Ctrl/Cmd+Shift+Z
     try {
         const isMac = navigator.platform.toUpperCase().includes('MAC');
         const modKey = isMac ? event.metaKey : event.ctrlKey;
-        if (modKey && event.key && event.key.toLowerCase() === 'z') {
+        if (!isTyping && modKey && normalizedKey === 'z') {
             event.preventDefault();
             if (event.shiftKey) redo(); else undo();
             return;
         }
-        if (modKey && event.key && event.key.toLowerCase() === 'y') {
+        if (!isTyping && modKey && normalizedKey === 'y') {
             event.preventDefault();
             redo();
             return;
@@ -2570,27 +3036,82 @@ function handleKeyDown(event) {
         console.error('Error in undo/redo keyboard shortcut handler:', e);
     }
 
-    if (!selectedEntity) return;
+    if (isTyping) return;
 
-    if (['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(event.key)) {
+    if (!event.altKey && !event.ctrlKey && !event.metaKey) {
+        if (normalizedKey === 'm') {
+            event.preventDefault();
+            const nextMode = mapMode === 'castle' ? 'base' : 'castle';
+            setMapMode(nextMode);
+            showShortcutToast(`Mode: ${nextMode === 'castle' ? 'Castle' : 'Base'} (M)`);
+            return;
+        }
+
+        if (normalizedKey === 'a') {
+            event.preventDefault();
+            const currentAllianceIndex = ALLIANCES.findIndex(a => a.id === normalizeAllianceId(activeAllianceId));
+            const nextAlliance = ALLIANCES[(currentAllianceIndex + 1) % ALLIANCES.length]?.id || DEFAULT_ALLIANCE_ID;
+            setActiveAlliance(nextAlliance);
+            showShortcutToast(`Alliance: ${getAllianceName(nextAlliance)} (A)`);
+            return;
+        }
+
+        if (normalizedKey === 'e') {
+            event.preventDefault();
+            if (getSelectedEntities().length) {
+                const deletedCount = deleteSelectedEntity();
+                showShortcutToast(
+                    deletedCount > 0
+                        ? `Deleted ${deletedCount === 1 ? 'selected entity' : `${deletedCount} entities`} (E)`
+                        : 'Selected object cannot be deleted'
+                );
+            } else {
+                setSelectedTool('delete', { showToast: true });
+            }
+            return;
+        }
+
+        const shortcutTool = TOOL_SHORTCUT_KEY_MAP[normalizedKey];
+        if (shortcutTool) {
+            event.preventDefault();
+            if (shortcutTool === 'enemyzone' && mapMode !== 'castle') {
+                showShortcutToast('Enemy Zone only in Castle mode');
+                return;
+            }
+            setSelectedTool(shortcutTool, { showToast: true });
+            return;
+        }
+    }
+
+    const selectedNow = getSelectedEntities();
+    if (!selectedNow.length) return;
+
+    if (!selectedEntity || !selectedEntities.has(selectedEntity)) {
+        selectedEntity = selectedNow[selectedNow.length - 1];
+    }
+
+    if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(key)) {
         event.preventDefault();
-    }    
+    }
 
-    // City name editing
-    if (selectedEntity.type === 'city' &&
-        !['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Delete'].includes(event.key)
+    const singleSelection = selectedNow.length === 1;
+
+    // City name editing (single selected city only)
+    if (singleSelection &&
+        selectedEntity.type === 'city' &&
+        !['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Delete'].includes(key)
     ) {
-        if (event.key === 'Enter') {
+        if (key === 'Enter') {
             selectedEntity.isEditing = false;
-        } else if (event.key === 'Backspace') {
+        } else if (key === 'Backspace') {
             event.preventDefault();
             selectedEntity.name = selectedEntity.name ? selectedEntity.name.slice(0, -1) : '';
-        } else if (event.key.length === 1) { 
+        } else if (key.length === 1) {
             if (!selectedEntity.isEditing) {
                 selectedEntity.name = '';
                 selectedEntity.isEditing = true;
             }
-            selectedEntity.name += event.key;
+            selectedEntity.name += key;
         }
         redraw();
         updateCityList();
@@ -2598,60 +3119,88 @@ function handleKeyDown(event) {
         return;
     }
 
-    if (event.key === 'Delete') {
+    if (key === 'Delete') {
         deleteSelectedEntity();
         return;
     }
 
-    // Movement with arrow keys
-    let newX = selectedEntity.x;
-    let newY = selectedEntity.y;
-    
-    if (event.key === 'ArrowUp') {
-        newY -= 1;
-    } else if (event.key === 'ArrowDown') {
-        newY += 1;
-    } else if (event.key === 'ArrowLeft') {
-        newX -= 1;
-    } else if (event.key === 'ArrowRight') {
-        newX += 1;
+    let deltaX = 0;
+    let deltaY = 0;
+    if (key === 'ArrowUp') {
+        deltaY = -1;
+    } else if (key === 'ArrowDown') {
+        deltaY = 1;
+    } else if (key === 'ArrowLeft') {
+        deltaX = -1;
+    } else if (key === 'ArrowRight') {
+        deltaX = 1;
     }
-    
-    if (isPositionValid(newX, newY, selectedEntity)) {
-        selectedEntity.x = newX;
-        selectedEntity.y = newY;
+
+    if (deltaX === 0 && deltaY === 0) return;
+
+    if (singleSelection) {
+        const newX = selectedEntity.x + deltaX;
+        const newY = selectedEntity.y + deltaY;
+        if (isPositionValid(newX, newY, selectedEntity)) {
+            selectedEntity.x = newX;
+            selectedEntity.y = newY;
+            redraw();
+            markUnsavedChanges();
+        }
+        return;
+    }
+
+    const movableSelection = selectedNow.filter(entity => !entity.locked);
+    if (!movableSelection.length) return;
+    const ignoreEntities = new Set(movableSelection);
+    const canMove = movableSelection.every(entity =>
+        isPositionValid(entity.x + deltaX, entity.y + deltaY, entity, ignoreEntities)
+    );
+
+    if (canMove) {
+        movableSelection.forEach(entity => {
+            entity.x += deltaX;
+            entity.y += deltaY;
+        });
         redraw();
         markUnsavedChanges();
     }
 }
 
 function deleteSelectedEntity() {
-    if (!selectedEntity) return;
-    // Do not allow deleting locked entities (castle/turret)
-    if (selectedEntity.locked) return;
-    
-    const index = entities.indexOf(selectedEntity);
-    if (index !== -1) {
-        if (selectedEntity.type === 'city') {
-            entities.splice(index, 1);
-            renumberCities();
-        } else if (selectedEntity.type === 'building') {
-            bearTraps = bearTraps.filter(trap => trap !== selectedEntity);
-            entities.splice(index, 1);
-        } else if (selectedEntity.type === 'enemyzone') {
-            enemyZones = enemyZones.filter(zone => zone !== selectedEntity);
-            entities.splice(index, 1);
-        } else {
-            entities.splice(index, 1);
+    const selectedNow = getSelectedEntities();
+    if (!selectedNow.length) return 0;
+
+    const deletable = selectedNow.filter(entity => !entity.locked);
+    if (!deletable.length) return 0;
+
+    let removedCities = false;
+    deletable.forEach(entity => {
+        const index = entities.indexOf(entity);
+        if (index === -1) return;
+
+        if (entity.type === 'city') {
+            removedCities = true;
+        } else if (entity.type === 'building') {
+            bearTraps = bearTraps.filter(trap => trap !== entity);
+        } else if (entity.type === 'enemyzone') {
+            enemyZones = enemyZones.filter(zone => zone !== entity);
         }
-        selectedEntity = null;
-        stopSelectionPulse();
-        redraw();
-        updateCounters();
-        updateCityList();
-        markUnsavedChanges();
-        pushHistory();
+
+        entities.splice(index, 1);
+    });
+
+    if (removedCities) {
+        renumberCities();
     }
+
+    clearSelection();
+    redraw();
+    updateCounters();
+    updateCityList();
+    markUnsavedChanges();
+    pushHistory();
+    return deletable.length;
 }
 
 function updateCityList() {
@@ -2731,8 +3280,7 @@ function updateCityList() {
     others.sort(comparator);
 
     const selectCityFromList = (city) => {
-        selectedEntity = city;
-        startSelectionPulse();
+        setSelection([city], { primaryEntity: city, pulse: true });
         redraw();
     };
 
@@ -3835,7 +4383,7 @@ function exportPlayerNamesCSV({ onlyNamed = false } = {}) {
             clearLongPress();
             longPressTimer = setTimeout(()=>{
                 // If something is selected, delete it
-                if (selectedEntity){
+                if (getSelectedEntities().length){
                     deleteSelectedEntity();
                 }
             }, LONG_PRESS_MS);
@@ -3935,6 +4483,10 @@ function exportPlayerNamesCSV({ onlyNamed = false } = {}) {
             const rect = canvas.getBoundingClientRect();
             const event = { clientX: x + rect.left, clientY: y + rect.top };
             selectEntity(event);
+        } else if (selectedType === 'delete') {
+            const rect = canvas.getBoundingClientRect();
+            const event = { clientX: x + rect.left, clientY: y + rect.top };
+            eraseEntityAtEvent(event);
         } else {
             // Simulate an addEntity at (x, y)
             const rect = canvas.getBoundingClientRect();
@@ -4046,8 +4598,7 @@ function applySnapshot(snapshot) {
         // Reconstruct derived arrays
         bearTraps = entities.filter(e => e.type === 'building');
         cityCounterId = state.cityCounterId || 1;
-        selectedEntity = null;
-        stopSelectionPulse();
+        clearSelection();
         redraw();
         updateCounters();
         updateCityList();

--- a/layout-planner/js/script.js
+++ b/layout-planner/js/script.js
@@ -75,6 +75,7 @@ let isBoxSelecting = false;
 let selectionBoxStart = null;
 let selectionBoxCurrent = null;
 let selectionBoxAdditive = false;
+let hasPendingEraseHistory = false;
 let lastMouseX = 0;
 let lastMouseY = 0;
 let hasUnsavedChanges = false;
@@ -188,6 +189,12 @@ function refreshEraserCursorForCurrentPointer(toolType = selectedType) {
         updateEraserCursorPosition(lastPointerClientX, lastPointerClientY);
     }
     setEraserCursorVisible(true);
+}
+
+function flushPendingEraseHistory() {
+    if (!hasPendingEraseHistory) return;
+    pushHistory();
+    hasPendingEraseHistory = false;
 }
 
 function updateCanvasCursorForTool(toolType = selectedType) {
@@ -1543,7 +1550,7 @@ function selectEntity(event, { additive = false, toggle = false, pulse = false }
     return clickedEntity;
 }
 
-function eraseEntityAtEvent(event) {
+function eraseEntityAtEvent(event, { deferHistory = false } = {}) {
     if (selectedType !== 'delete') return false;
 
     const rect = canvas.getBoundingClientRect();
@@ -1557,7 +1564,7 @@ function eraseEntityAtEvent(event) {
     }
 
     setSelection([clickedEntity], { primaryEntity: clickedEntity, pulse: false });
-    return deleteSelectedEntity() > 0;
+    return deleteSelectedEntity({ pushHistoryEntry: !deferHistory }) > 0;
 }
 
 // ===== INPUT HANDLING =====
@@ -1713,8 +1720,12 @@ function handleMouseDown(event) {
             lastMouseX = mouseX;
             lastMouseY = mouseY;
         } else if (selectedType === 'delete') {
+            flushPendingEraseHistory();
+            hasPendingEraseHistory = false;
             isErasing = true;
-            eraseEntityAtEvent(event);
+            if (eraseEntityAtEvent(event, { deferHistory: true })) {
+                hasPendingEraseHistory = true;
+            }
         } else {
             addEntity(event);
         }
@@ -1742,7 +1753,9 @@ function handleMouseMove(event) {
         updateBoxSelection(mouseX, mouseY);
         redraw();
     } else if (isErasing && selectedType === 'delete') {
-        eraseEntityAtEvent(event);
+        if (eraseEntityAtEvent(event, { deferHistory: true })) {
+            hasPendingEraseHistory = true;
+        }
     } else if (isDragging && dragSelectionStart.length) {
         const gridPos = screenToDiamond(mouseX, mouseY);
         const deltaX = gridPos.x - dragOffsetX;
@@ -1764,6 +1777,7 @@ function handleMouseUp(event) {
         isPanning = false;
     } else if (event.button === 0) {
         isErasing = false;
+        flushPendingEraseHistory();
         if (isBoxSelecting) {
             finalizeBoxSelection();
             return;
@@ -1821,6 +1835,7 @@ function setSelectedTool(toolType, { showToast = false } = {}) {
     );
     if (!knownToolButton) return false;
 
+    flushPendingEraseHistory();
     selectedType = toolType;
     clearSelection();
     isErasing = false;
@@ -3167,7 +3182,7 @@ function handleKeyDown(event) {
     }
 }
 
-function deleteSelectedEntity() {
+function deleteSelectedEntity({ pushHistoryEntry = true } = {}) {
     const selectedNow = getSelectedEntities();
     if (!selectedNow.length) return 0;
 
@@ -3199,7 +3214,9 @@ function deleteSelectedEntity() {
     updateCounters();
     updateCityList();
     markUnsavedChanges();
-    pushHistory();
+    if (pushHistoryEntry) {
+        pushHistory();
+    }
     return deletable.length;
 }
 

--- a/layout-planner/js/script.js
+++ b/layout-planner/js/script.js
@@ -1664,6 +1664,43 @@ function applyDraggedSelection(deltaX, deltaY) {
     });
 }
 
+function getDraggedSelectionDelta() {
+    if (!dragSelectionStart.length) return { x: 0, y: 0 };
+    const first = dragSelectionStart[0];
+    return {
+        x: first.entity.x - first.x,
+        y: first.entity.y - first.y
+    };
+}
+
+function tryApplyDraggedSelectionDelta(targetDeltaX, targetDeltaY) {
+    if (!dragSelectionStart.length) return false;
+
+    const currentDelta = getDraggedSelectionDelta();
+    if (targetDeltaX === currentDelta.x && targetDeltaY === currentDelta.y) {
+        return false;
+    }
+
+    const fallbackDeltas = [
+        { x: targetDeltaX, y: targetDeltaY },
+        { x: targetDeltaX, y: currentDelta.y },
+        { x: currentDelta.x, y: targetDeltaY }
+    ];
+
+    const seen = new Set();
+    for (const candidate of fallbackDeltas) {
+        const key = `${candidate.x},${candidate.y}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        if (!canMoveDraggedSelection(candidate.x, candidate.y)) continue;
+        applyDraggedSelection(candidate.x, candidate.y);
+        return true;
+    }
+
+    return false;
+}
+
 function beginSelectionDragFromEntity(clickedEntity, gridPos) {
     const movableSelection = getSelectedEntities().filter(entity => !entity.locked);
     if (!movableSelection.length || !movableSelection.includes(clickedEntity)) return;
@@ -1795,8 +1832,7 @@ function handleMouseMove(event) {
         const deltaX = gridPos.x - dragOffsetX;
         const deltaY = gridPos.y - dragOffsetY;
 
-        if ((deltaX !== 0 || deltaY !== 0) && canMoveDraggedSelection(deltaX, deltaY)) {
-            applyDraggedSelection(deltaX, deltaY);
+        if (tryApplyDraggedSelectionDelta(deltaX, deltaY)) {
             hasDragMovement = true;
             redraw();
             markUnsavedChanges();
@@ -4388,8 +4424,7 @@ function exportPlayerNamesCSV({ onlyNamed = false } = {}) {
                 const deltaX = gridPos.x - dragOffsetX;
                 const deltaY = gridPos.y - dragOffsetY;
 
-                if ((deltaX !== 0 || deltaY !== 0) && canMoveDraggedSelection(deltaX, deltaY)) {
-                    applyDraggedSelection(deltaX, deltaY);
+                if (tryApplyDraggedSelectionDelta(deltaX, deltaY)) {
                     hasDragMovement = true;
                     redraw();
                     markUnsavedChanges();


### PR DESCRIPTION
add quick select to modes, buildings
<img width="764" height="105" alt="grafik" src="https://github.com/user-attachments/assets/c98ee7e3-6066-475a-ae62-d82fc27358b7" />
<img width="315" height="368" alt="grafik" src="https://github.com/user-attachments/assets/76c19efa-443b-4e42-9237-07c91b1163bd" />

switch "delete" to an "eraser"-mode if no entity is selected. (drag to delete)
<img width="602" height="463" alt="grafik" src="https://github.com/user-attachments/assets/414e196e-eb7c-451c-beb0-d5158f499dc6" />

add drag to select mode (or ctrl/cmd+click) to select and move multiple entities
<img width="812" height="553" alt="grafik" src="https://github.com/user-attachments/assets/34dd6d2b-1801-4aee-84ca-b2ed1d59b475" />


general cleanup and refinement of touch controls